### PR TITLE
Fragmentert element

### DIFF
--- a/src/main/kotlin/ApplicationContext.kt
+++ b/src/main/kotlin/ApplicationContext.kt
@@ -64,11 +64,11 @@ open class ApplicationContext(env: Map<String, String>) {
         objectMapper = objectMapper,
     )
 
-    val rootRouter = RootRouter(stillingFeedKlient)
+    val rootRouter = RootRouter()
 
-    open val konsumentService by lazy { KonsumentService(stillingFeedKlient, objectMapper) }
-    val konsumentRouter by lazy { KonsumentRouter(konsumentService) }
+    val konsumentService = KonsumentService(stillingFeedKlient, objectMapper)
+    val konsumentRouter = KonsumentRouter(konsumentService)
 
     val tokenService = TokenService(stillingFeedKlient, oneTimeSecretKlient)
-    val tokenRouter = TokenRouter(tokenService)
+    val tokenRouter = TokenRouter(tokenService, konsumentService)
 }

--- a/src/main/kotlin/Fragment.kt
+++ b/src/main/kotlin/Fragment.kt
@@ -1,0 +1,38 @@
+package no.nav.pam.stilling.feed.admin
+
+import kotlinx.html.*
+import kotlinx.html.consumers.delayed
+import kotlinx.html.consumers.onFinalizeMap
+import kotlinx.html.stream.HTMLStreamBuilder
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+class FRAGMENT(
+    initialAttributes: Map<String, String>,
+    override val consumer: TagConsumer<*>,
+) : HTMLTag("fragment", consumer, initialAttributes, null, false, false), HtmlBlockTag
+
+/**
+ * En tag som kan brukes til å sende flere elementer uten en wrapper via createHTML
+ * Inspirert av Fragment komponenten i React: [https://react.dev/reference/react/Fragment]
+ */
+@HtmlTagMarker
+@OptIn(ExperimentalContracts::class)
+inline fun <T, C : TagConsumer<T>> C.fragment(
+    classes: String? = null,
+    crossinline block: FRAGMENT.() -> Unit = {}
+): T {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return FRAGMENT(attributesMapOf("class", classes), this).visitAndFinalize(this, block)
+}
+
+/**
+ * Identisk med createHTML bortsett fra at den fjerner fragmet tagger
+ */
+fun createFragmentHTML(prettyPrint: Boolean = true, xhtmlCompatible: Boolean = false): TagConsumer<String> =
+    HTMLStreamBuilder(
+        StringBuilder(),
+        prettyPrint,
+        xhtmlCompatible
+    ).onFinalizeMap { sb, _ -> sb.toString().replace(Regex("<fragment>|</fragment>"), "") }.delayed()

--- a/src/main/kotlin/RootRouter.kt
+++ b/src/main/kotlin/RootRouter.kt
@@ -3,8 +3,6 @@ package no.nav.pam.stilling.feed.admin
 import io.javalin.Javalin
 import io.javalin.http.Context
 import kotlinx.html.*
-import no.nav.pam.stilling.feed.admin.komponenter.Input
-import no.nav.pam.stilling.feed.admin.konsument.KonsumentForm
 import no.nav.pam.stilling.feed.admin.token.GenererTokenForm
 
 class RootRouter(
@@ -20,34 +18,22 @@ class RootRouter(
     private fun opprettKonsument(ctx: Context) {
         ctx.html(indexHTML {
             section {
-                id = "konsumentForm"
-
-                h2 { +"Opprett konsument" }
-
-                p { +"Fyll ut skjema for å opprette en ny konsument." }
-
-                KonsumentForm()
+                id = "konsument"
+                attributes["hx-get"] = "/konsument/form"
+                attributes["hx-target"] = "#konsument"
+                attributes["hx-trigger"] = "load"
             }
         })
     }
 
     private fun finnKonsument(ctx: Context) {
         ctx.html(indexHTML {
-            h2 { +"Søk etter konsument" }
-
-            Input {
-                this.id = "konsumentSok"
-                this.name = "q"
-                type = InputType.text
-                autoFocus = true
+            div {
+                id = "konsumentSok"
                 attributes["hx-get"] = "/konsument/sok"
-                attributes["hx-target"] = "#konsumentTabell"
-                attributes["hx-trigger"] = "load, input changed delay:250ms"
-                attributes["hx-swap"] = "outerHTML"
-                placeholder = "ID, Identifikator, E-post, Telefon eller Kontaktperson"
+                attributes["hx-target"] = "#konsumentSok"
+                attributes["hx-trigger"] = "load"
             }
-
-            div { id = "konsumentTabell" }
         })
     }
 

--- a/src/main/kotlin/RootRouter.kt
+++ b/src/main/kotlin/RootRouter.kt
@@ -3,11 +3,8 @@ package no.nav.pam.stilling.feed.admin
 import io.javalin.Javalin
 import io.javalin.http.Context
 import kotlinx.html.*
-import no.nav.pam.stilling.feed.admin.token.GenererTokenForm
 
-class RootRouter(
-    private val stillingFeedKlient: StillingFeedKlient
-) {
+class RootRouter {
     fun setupRoutes(javalin: Javalin) {
         javalin.get("/") { it.redirect("/konsument") }
         javalin.get("/konsument/opprett") { opprettKonsument(it) }
@@ -40,13 +37,10 @@ class RootRouter(
     private fun genererToken(ctx: Context) {
         ctx.html(indexHTML {
             section {
-                id = "genererTokenForm"
-
-                h2 { +"Generer token" }
-
-                p { +"Velg konsument for å generere et token og en utfylt e-post." }
-
-                GenererTokenForm(stillingFeedKlient.hentKonsumenter(""))
+                id = "genererToken"
+                attributes["hx-get"] = "/token/form"
+                attributes["hx-target"] = "#genererToken"
+                attributes["hx-trigger"] = "load"
             }
         })
     }

--- a/src/main/kotlin/konsument/KonsumentForm.kt
+++ b/src/main/kotlin/konsument/KonsumentForm.kt
@@ -7,8 +7,7 @@ import no.nav.pam.stilling.feed.admin.komponenter.Input
 fun FlowContent.KonsumentForm() {
     form {
         attributes["hx-post"] = "/konsument/opprett"
-        attributes["hx-target"] = "#konsumentForm"
-        attributes["hx-swap"] = "outerHTML"
+        attributes["hx-target"] = "#konsument"
 
         Input {
             name = "identifikator"

--- a/src/main/kotlin/konsument/KonsumentRouter.kt
+++ b/src/main/kotlin/konsument/KonsumentRouter.kt
@@ -3,8 +3,10 @@ package no.nav.pam.stilling.feed.admin.konsument
 import io.javalin.Javalin
 import io.javalin.http.Context
 import kotlinx.html.*
-import kotlinx.html.stream.createHTML
+import no.nav.pam.stilling.feed.admin.createFragmentHTML
+import no.nav.pam.stilling.feed.admin.fragment
 import no.nav.pam.stilling.feed.admin.komponenter.Button
+import no.nav.pam.stilling.feed.admin.komponenter.Input
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -16,28 +18,78 @@ class KonsumentRouter(
     }
 
     fun setupRoutes(javalin: Javalin) {
+        javalin.get("/konsument/sok") { lastInnFinnKonsument(it) }
+        javalin.get("/konsument/tabell") { håndterKonsumentTabell(it) }
+        javalin.get("/konsument/form") { lastInnKonsumentForm(it) }
         javalin.post("/konsument/opprett") { håndterOpprettKonsument(it) }
-        javalin.get("/konsument/sok") { håndterFinnKonsument(it) }
     }
 
-    private fun håndterFinnKonsument(ctx: Context) {
+    private fun lastInnFinnKonsument(ctx: Context) {
+        ctx.html(createFragmentHTML().fragment {
+            h2 {
+                style = "text-align: center;"
+                +"Søk etter konsument"
+            }
+
+            Input {
+                attributes["style"] = """
+                    margin: 2rem 0 4rem 0;
+                    max-width: 800px;
+                    min-width: 70%;
+                """.trimIndent()
+                id = "konsumentSok"
+                name = "q"
+                type = InputType.text
+                autoFocus = true
+                attributes["hx-get"] = "/konsument/tabell"
+                attributes["hx-target"] = "#konsumentTabell"
+                attributes["hx-trigger"] = "load, input changed delay:250ms"
+                placeholder = "ID, Identifikator, E-post, Telefon eller Kontaktperson"
+            }
+
+            div { id = "konsumentTabell" }
+        })
+    }
+
+    private fun håndterKonsumentTabell(ctx: Context) {
         val spørring = ctx.queryParam("q")
         log.info("Mottar søk etter konsument med spørring: $spørring")
         val konsumenter = konsumentService.hentKonsumenter(spørring)
-        ctx.html(createHTML().div {
-            id = "konsumentTabell"
-            style = "width: 100%;"
-            div { +"${konsumenter.size} ${if (konsumenter.size == 1) "konsument" else "konsumenter"}" }
-            KonsumentTabell(konsumenter)
+        ctx.html(createFragmentHTML().fragment {
+            p { +"${konsumenter.size} ${if (konsumenter.size == 1) "konsument" else "konsumenter"}" }
+
+            table {
+                thead {
+                    tr {
+                        th { +"ID" }
+                        th { +"Identifikator" }
+                        th { +"E-post" }
+                        th { +"Telefon" }
+                        th { +"Kontaktperson" }
+                        th { +"Opprettet" }
+                    }
+                }
+                tbody {
+                    this@table.KonsumentTabell(konsumenter)
+                }
+            }
+        })
+    }
+
+    private fun lastInnKonsumentForm(ctx: Context) {
+        ctx.html(createFragmentHTML().fragment {
+            h2 { +"Opprett konsument" }
+
+            p { +"Fyll ut skjema for å opprette en ny konsument." }
+
+            KonsumentForm()
         })
     }
 
     private fun håndterOpprettKonsument(ctx: Context) {
         val request = KonsumentDTO.fraHtmlForm(ctx.formParamMap())
         val konsument = konsumentService.opprettKonsument(request)
-        ctx.html(createHTML().section {
-            id = "konsument"
-
+        ctx.html(createFragmentHTML().fragment {
             h2 { +"Opprettet konsument" }
 
             pre {
@@ -49,7 +101,7 @@ class KonsumentRouter(
 
             Button {
                 attributes["hx-get"] = "/konsument/opprett"
-                attributes["hx-target"] = "body"
+                attributes["hx-target"] = "#konsument"
                 attributes["autofocus"] = "true"
                 label = "Opprett ny konsument"
             }

--- a/src/main/kotlin/konsument/KonsumentTabell.kt
+++ b/src/main/kotlin/konsument/KonsumentTabell.kt
@@ -2,31 +2,21 @@ package no.nav.pam.stilling.feed.admin.konsument
 
 import kotlinx.html.*
 
-fun FlowContent.KonsumentTabell(konsumenter: List<KonsumentDTO>) {
-    table {
+fun TABLE.KonsumentTabell(konsumenter: List<KonsumentDTO>) {
+    konsumenter.forEach { konsument ->
         tr {
-            th { +"ID" }
-            th { +"Identifikator" }
-            th { +"E-post" }
-            th { +"Telefon" }
-            th { +"Kontaktperson" }
-            th { +"Opprettet" }
-        }
-        konsumenter.forEach { konsument ->
-            tr {
-                td {
-                    style = "min-width: 300px;"
-                    code { +konsument.id.toString() }
-                }
-                td { +konsument.identifikator }
-                td { +konsument.email }
-                td {
-                    style = "min-width: 96px;"
-                    +konsument.telefon
-                }
-                td { +konsument.kontaktperson }
-                td { +konsument.opprettet.toString() }
+            td {
+                style = "min-width: 300px;"
+                code { +konsument.id.toString() }
             }
+            td { +konsument.identifikator }
+            td { +konsument.email }
+            td {
+                style = "min-width: 96px;"
+                +konsument.telefon
+            }
+            td { +konsument.kontaktperson }
+            td { +konsument.opprettet.toString() }
         }
     }
 }

--- a/src/main/kotlin/token/GenererTokenForm.kt
+++ b/src/main/kotlin/token/GenererTokenForm.kt
@@ -9,7 +9,7 @@ fun FlowContent.GenererTokenForm(
 ) {
     form {
         attributes["hx-post"] = "/token/generer"
-        attributes["hx-target"] = "#genererTokenForm"
+        attributes["hx-target"] = "#genererToken"
         attributes["hx-swap"] = "outerHTML"
         attributes["hx-indicator"] = "#laster"
 
@@ -44,13 +44,6 @@ fun FlowContent.GenererTokenForm(
             type = ButtonType.submit
             variant = ButtonVariant.PRIMARY
             label = "Generer token"
-        }
-
-        div {
-            id = "laster"
-            classes = setOf("navds-loader")
-            style = "display: none; width: 100%; font-size: 2rem; text-align: center;"
-            +"Vær tålmodig, krønsjer noen tall..."
         }
     }
 }

--- a/src/main/resources/public/style.css
+++ b/src/main/resources/public/style.css
@@ -124,12 +124,6 @@ input, select {
     border-radius: var(--a-border-radius-medium);
 }
 
-#konsumentSok {
-    margin: 2rem 0 4rem 0;
-    max-width: 800px;
-    min-width: 70%;
-}
-
 .htmx-request {
     display: inline-block !important;
 }


### PR DESCRIPTION
Lager en `fragment` tag som sletter seg selv når den brukes med en `createFragmentHTML`-streambuilder. Gjør det mulig å sende html uten en wrapper.

Sterkt inspirert av løsningen til React: https://react.dev/reference/react/Fragment