### PR TITLE
Oppretter tester for Routerene

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,9 @@ dependencies {
     implementation("com.auth0:java-jwt:4.5.0")
 
     testImplementation(kotlin("test"))
+    testImplementation("it.skrape:skrapeit:1.2.2")
+    testImplementation("org.assertj:assertj-core:4.0.0-M1")
+    testImplementation("io.mockk:mockk:1.14.2")
 }
 
 tasks.test {

--- a/src/main/kotlin/ApplicationContext.kt
+++ b/src/main/kotlin/ApplicationContext.kt
@@ -69,6 +69,6 @@ open class ApplicationContext(env: Map<String, String>) {
     open val konsumentService by lazy { KonsumentService(stillingFeedKlient, objectMapper) }
     open val konsumentRouter by lazy { KonsumentRouter(konsumentService) }
 
-    val tokenService = TokenService(stillingFeedKlient, oneTimeSecretKlient)
-    val tokenRouter by lazy { TokenRouter(tokenService, konsumentService) }
+    open val tokenService by lazy { TokenService(stillingFeedKlient, oneTimeSecretKlient) }
+    open val tokenRouter by lazy { TokenRouter(tokenService, konsumentService) }
 }

--- a/src/main/kotlin/ApplicationContext.kt
+++ b/src/main/kotlin/ApplicationContext.kt
@@ -66,9 +66,9 @@ open class ApplicationContext(env: Map<String, String>) {
 
     val rootRouter = RootRouter()
 
-    val konsumentService = KonsumentService(stillingFeedKlient, objectMapper)
-    val konsumentRouter = KonsumentRouter(konsumentService)
+    open val konsumentService by lazy { KonsumentService(stillingFeedKlient, objectMapper) }
+    open val konsumentRouter by lazy { KonsumentRouter(konsumentService) }
 
     val tokenService = TokenService(stillingFeedKlient, oneTimeSecretKlient)
-    val tokenRouter = TokenRouter(tokenService, konsumentService)
+    val tokenRouter by lazy { TokenRouter(tokenService, konsumentService) }
 }

--- a/src/main/kotlin/token/TokenRouter.kt
+++ b/src/main/kotlin/token/TokenRouter.kt
@@ -2,6 +2,7 @@ package no.nav.pam.stilling.feed.admin.token
 
 import io.javalin.Javalin
 import io.javalin.http.Context
+import io.javalin.http.HttpStatus
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
 import no.nav.pam.stilling.feed.admin.createFragmentHTML
@@ -83,6 +84,7 @@ class TokenRouter(
         })
     } catch (e: Exception) {
         log.error("Feil ved generering av token", e)
+        ctx.status(HttpStatus.INTERNAL_SERVER_ERROR)
         ctx.html(createHTML().section {
             h2 { +"Åisann, det skjedde visst noe feil!" }
 

--- a/src/test/kotlin/RootRouterTest.kt
+++ b/src/test/kotlin/RootRouterTest.kt
@@ -1,0 +1,87 @@
+import app.TestRunningApplication
+import io.javalin.http.ContentType
+import io.javalin.http.HttpStatus
+import it.skrape.core.htmlDocument
+import it.skrape.fetcher.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RootRouterTest : TestRunningApplication() {
+    @Test
+    fun `Skal redirecte på root path`() {
+        skrape(HttpFetcher) {
+            request {
+                url = "$lokalBaseUrl/"
+                method = Method.GET
+                followRedirects = false
+            }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.FOUND.code) }
+            }
+        }
+    }
+
+    @Test
+    fun `Skal laste siden for 'finn konsument'`() {
+        skrape(HttpFetcher) {
+            request {
+                url = "$lokalBaseUrl/konsument"
+                method = Method.GET
+            }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.OK.code) }
+                assertThat(contentType).contains(ContentType.TEXT_HTML.mimeType)
+                htmlDocument {
+                    findFirst("#konsumentSok") {
+                        assertThat(tagName).isEqualTo("div")
+                        assertThat(attributes["hx-get"]).isEqualTo("/konsument/sok")
+                        assertThat(attributes["hx-target"]).isEqualTo("#konsumentSok")
+                        assertThat(attributes["hx-trigger"]).isEqualTo("load")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Skal laste siden for 'opprett konsument'`() {
+        skrape(HttpFetcher) {
+            request {
+                url = "$lokalBaseUrl/konsument/opprett"
+                method = Method.GET
+            }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.OK.code) }
+                htmlDocument {
+                    findFirst("#konsument") {
+                        assertThat(tagName).isEqualTo("section")
+                        assertThat(attributes["hx-get"]).isEqualTo("/konsument/form")
+                        assertThat(attributes["hx-target"]).isEqualTo("#konsument")
+                        assertThat(attributes["hx-trigger"]).isEqualTo("load")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Skal laste siden for 'generer token'`() {
+        skrape(HttpFetcher) {
+            request {
+                url = "$lokalBaseUrl/token/generer"
+                method = Method.GET
+            }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.OK.code) }
+                htmlDocument {
+                    findFirst("#genererToken") {
+                        assertThat(tagName).isEqualTo("section")
+                        assertThat(attributes["hx-get"]).isEqualTo("/token/form")
+                        assertThat(attributes["hx-target"]).isEqualTo("#genererToken")
+                        assertThat(attributes["hx-trigger"]).isEqualTo("load")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/app/TestApplication.kt
+++ b/src/test/kotlin/app/TestApplication.kt
@@ -1,0 +1,9 @@
+package app
+
+import no.nav.pam.stilling.feed.admin.app.env
+import no.nav.pam.stilling.feed.admin.startApp
+
+fun main() {
+    val testAppCtx = TestApplicationContext(env)
+    testAppCtx.startApp()
+}

--- a/src/test/kotlin/app/TestApplicationContext.kt
+++ b/src/test/kotlin/app/TestApplicationContext.kt
@@ -1,0 +1,13 @@
+package app
+
+import io.mockk.mockk
+import no.nav.pam.stilling.feed.admin.ApplicationContext
+import no.nav.pam.stilling.feed.admin.konsument.KonsumentRouter
+import no.nav.pam.stilling.feed.admin.konsument.KonsumentService
+
+class TestApplicationContext(
+    private val testEnv: MutableMap<String, String>,
+) : ApplicationContext(testEnv) {
+    val konsumentServiceMock = mockk<KonsumentService>()
+    override val konsumentRouter by lazy { KonsumentRouter(konsumentServiceMock) }
+}

--- a/src/test/kotlin/app/TestApplicationContext.kt
+++ b/src/test/kotlin/app/TestApplicationContext.kt
@@ -4,10 +4,15 @@ import io.mockk.mockk
 import no.nav.pam.stilling.feed.admin.ApplicationContext
 import no.nav.pam.stilling.feed.admin.konsument.KonsumentRouter
 import no.nav.pam.stilling.feed.admin.konsument.KonsumentService
+import no.nav.pam.stilling.feed.admin.token.TokenRouter
+import no.nav.pam.stilling.feed.admin.token.TokenService
 
 class TestApplicationContext(
     private val testEnv: MutableMap<String, String>,
 ) : ApplicationContext(testEnv) {
     val konsumentServiceMock = mockk<KonsumentService>()
     override val konsumentRouter by lazy { KonsumentRouter(konsumentServiceMock) }
+
+    val tokenServiceMock = mockk<TokenService>()
+    override val tokenRouter by lazy { TokenRouter(tokenServiceMock, konsumentServiceMock) }
 }

--- a/src/test/kotlin/app/TestRunningApplication.kt
+++ b/src/test/kotlin/app/TestRunningApplication.kt
@@ -1,0 +1,14 @@
+package app
+
+import no.nav.pam.stilling.feed.admin.app.env
+import no.nav.pam.stilling.feed.admin.startApp
+
+abstract class TestRunningApplication {
+    companion object {
+        const val lokalBaseUrl = "http://localhost:3000"
+
+        @JvmStatic
+        val appCtx = TestApplicationContext(env)
+        val javalin = appCtx.startApp()
+    }
+}

--- a/src/test/kotlin/konsument/KonsumentRouterTest.kt
+++ b/src/test/kotlin/konsument/KonsumentRouterTest.kt
@@ -1,0 +1,209 @@
+package konsument
+
+import app.TestRunningApplication
+import io.javalin.http.ContentType
+import io.javalin.http.HttpStatus
+import io.mockk.every
+import it.skrape.core.htmlDocument
+import it.skrape.fetcher.*
+import it.skrape.selects.*
+import no.nav.pam.stilling.feed.admin.konsument.KonsumentDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+fun KonsumentDTO.Companion.genererTilfeldig(): KonsumentDTO {
+    return KonsumentDTO(
+        id = UUID.randomUUID(),
+        identifikator = "identifikator-${UUID.randomUUID()}",
+        email = "test-${UUID.randomUUID()}@example.com",
+        telefon = "0047${Random().nextInt(10000000, 99999999)}",
+        kontaktperson = "Kontaktperson ${UUID.randomUUID()}",
+        opprettet = LocalDateTime.now()
+    )
+}
+
+class KonsumentRouterTest : TestRunningApplication() {
+    val konsumentService = appCtx.konsumentServiceMock
+
+    @Test
+    fun `Skal laste siden for 'finn konsument'`() {
+        skrape(HttpFetcher) {
+            request { url = "$lokalBaseUrl/konsument/sok" }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.OK.code) }
+                assertThat(contentType).contains(ContentType.TEXT_HTML.mimeType)
+                htmlDocument {
+                    findAll("h2") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(eachTagName).isEqualTo(listOf("h2"))
+                        assertThat(text).isEqualTo("Søk etter konsument")
+                    }
+
+                    findAll("input") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(eachTagName).isEqualTo(listOf("input"))
+                        assertThat(first().id).isEqualTo("konsumentSok")
+                        assertThat(first().attributes["hx-get"]).isEqualTo("/konsument/tabell")
+                        assertThat(first().attributes["hx-target"]).isEqualTo("#konsumentTabell")
+                    }
+
+                    findAll("#konsumentTabell") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(first().tagName).isEqualTo("div")
+                        assertThat(first().html).isEmpty()
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Skal opprette en tabell gitt en liste med konsumenter`() {
+        val konsumenter = List(10) { KonsumentDTO.genererTilfeldig() }
+
+        every { konsumentService.hentKonsumenter(any()) } returns konsumenter
+
+        skrape(HttpFetcher) {
+            request { url = "$lokalBaseUrl/konsument/tabell" }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.OK.code) }
+                assertThat(contentType).contains(ContentType.TEXT_HTML.mimeType)
+                htmlDocument {
+                    findAll("p") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(text).isEqualTo("${konsumenter.size} konsumenter")
+                    }
+
+                    findAll("table") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(first().tagName).isEqualTo("table")
+
+                        findAll("thead") {
+                            assertThat(size).isEqualTo(1)
+                            assertThat(first().children.first().tagName).isEqualTo("tr")
+                            val tr = first().children.first()
+                            assertThat(tr.children.map { it.text }).containsExactly(
+                                "ID", "Identifikator", "E-post", "Telefon", "Kontaktperson", "Opprettet"
+                            )
+                        }
+
+                        findAll("tbody") {
+                            assertThat(size).isEqualTo(1)
+                            assertThat(first().children.size).isEqualTo(konsumenter.size)
+
+                            konsumenter.forEachIndexed { index, konsument ->
+                                val tr = first().children[index]
+                                assertThat(tr.tagName).isEqualTo("tr")
+                                assertThat(tr.children.map { it.text }).containsExactly(
+                                    konsument.id.toString(),
+                                    konsument.identifikator,
+                                    konsument.email,
+                                    konsument.telefon,
+                                    konsument.kontaktperson,
+                                    konsument.opprettet.toString()
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Skal laste siden for konsument skjemaet`() {
+        skrape(HttpFetcher) {
+            request { url = "$lokalBaseUrl/konsument/form" }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.OK.code) }
+                assertThat(contentType).contains(ContentType.TEXT_HTML.mimeType)
+                htmlDocument {
+                    findAll("h2") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(text).isEqualTo("Opprett konsument")
+                    }
+
+                    findAll("p") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(text).isEqualTo("Fyll ut skjema for å opprette en ny konsument.")
+                    }
+
+                    findAll("form") {
+                        assertThat(size).isEqualTo(1)
+
+                        findAll("input") { assertThat(size).isEqualTo(4) }
+                        findAll("button") { assertThat(size).isEqualTo(1) }
+                        findAll("label") {
+                            assertThat(size).isEqualTo(5)
+                            println(html)
+                            assertThat(map { it.text }).containsExactly(
+                                "Identifikator:", "E-post:", "Telefon:", "Kontaktperson:", "Legg til konsument"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Skal opprette en konsument via skjemaet`() {
+        val konsument = KonsumentDTO.genererTilfeldig()
+        val konsumentResponse = """
+                Opprettet ny konsument:
+                ID:             ${konsument.id}
+                Identifikator:  ${konsument.identifikator}
+                Email:          ${konsument.email}
+                Telefon:        ${konsument.telefon}
+                Kontaktperson:  ${konsument.kontaktperson}
+                Opprettet:      ${konsument.opprettet}
+            """.trimIndent()
+
+        every { konsumentService.opprettKonsument(any()) } returns konsumentResponse
+
+        skrape(HttpFetcher) {
+            request {
+                url = "$lokalBaseUrl/konsument/opprett"
+                method = Method.POST
+                body {
+                    form {
+                        "identifikator" to konsument.identifikator
+                        "email" to konsument.email
+                        "telefon" to konsument.telefon
+                        "kontaktperson" to konsument.kontaktperson
+                    }
+                }
+            }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.OK.code) }
+                assertThat(contentType).contains(ContentType.TEXT_HTML.mimeType)
+                htmlDocument {
+                    findAll("h2") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(text).isEqualTo("Opprettet konsument")
+                    }
+
+                    findAll("pre") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(first().text).contains(konsument.id.toString())
+                        assertThat(first().text).contains(konsument.identifikator)
+                        assertThat(first().text).contains(konsument.email)
+                        assertThat(first().text).contains(konsument.telefon)
+                        assertThat(first().text).contains(konsument.kontaktperson)
+                        assertThat(first().text).contains(konsument.opprettet.toString())
+                    }
+
+                    findAll("button") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(first().attributes["hx-get"]).isEqualTo("/konsument/opprett")
+                        assertThat(first().attributes["hx-target"]).isEqualTo("#konsument")
+                        assertThat(first().attributes["autofocus"]).isEqualTo("true")
+                        assertThat(first().text).isEqualTo("Opprett ny konsument")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/token/TokenRouterTest.kt
+++ b/src/test/kotlin/token/TokenRouterTest.kt
@@ -1,0 +1,201 @@
+package token
+
+import app.TestRunningApplication
+import io.javalin.http.ContentType
+import io.javalin.http.HttpStatus
+import io.mockk.every
+import it.skrape.core.*
+import it.skrape.fetcher.*
+import it.skrape.selects.*
+import konsument.genererTilfeldig
+import no.nav.pam.stilling.feed.admin.konsument.KonsumentDTO
+import no.nav.pam.stilling.feed.admin.token.TokenRequestDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.time.LocalDateTime
+import java.util.UUID
+
+fun TokenRequestDTO.Companion.genererTilfeldig(): TokenRequestDTO {
+    return TokenRequestDTO(
+        konsumentId = UUID.randomUUID(),
+        expires = LocalDateTime.now().plusDays(30)
+    )
+}
+
+class TokenRouterTest : TestRunningApplication() {
+    val tokenService = appCtx.tokenServiceMock
+    val konsumentService = appCtx.konsumentServiceMock
+
+    @Test
+    fun `Skal laste siden for 'generer token'`() {
+        val konsumenter = List(10) { KonsumentDTO.genererTilfeldig() }
+
+        every { konsumentService.hentKonsumenter(any()) } returns konsumenter
+
+        skrape(HttpFetcher) {
+            request { url = "$lokalBaseUrl/token/form" }
+            response {
+                status { assertThat(code).isEqualTo(200) }
+                assertThat(contentType).contains(ContentType.TEXT_HTML.mimeType)
+
+                htmlDocument {
+                    findAll("h2") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(eachTagName).isEqualTo(listOf("h2"))
+                        assertThat(text).isEqualTo("Generer token")
+                    }
+
+                    findAll("p") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(eachTagName).isEqualTo(listOf("p"))
+                        assertThat(text).isEqualTo("Velg konsument for å generere et token og en utfylt e-post.")
+                    }
+
+                    findAll("form") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(first().attributes["hx-post"]).isEqualTo("/token/generer")
+                        assertThat(first().attributes["hx-target"]).isEqualTo("#genererToken")
+                        assertThat(first().attributes["hx-swap"]).isEqualTo("outerHTML")
+                        assertThat(first().attributes["hx-indicator"]).isEqualTo("#laster")
+
+                        findAll("label") {
+                            assertThat(size).isEqualTo(3)
+                            assertThat(map { it.text }).containsExactly(
+                                "Velg konsument:",
+                                "Utløpsdato: (La være tom for ingen utløpsdato)",
+                                "Generer token"
+                            )
+                        }
+
+                        findAll("select") {
+                            assertThat(size).isEqualTo(1)
+                            assertThat(first().attributes["name"]).isEqualTo("konsumentId")
+
+                            findAll("option") {
+                                assertThat(size).isEqualTo(konsumenter.size)
+                                konsumenter.forEachIndexed { index, konsument ->
+                                    assertThat(this[index].attributes["value"]).isEqualTo(konsument.id.toString())
+                                    assertThat(this[index].text).isEqualTo(konsument.identifikator)
+                                }
+                            }
+                        }
+
+                        findAll("input") {
+                            assertThat(size).isEqualTo(1)
+                            assertThat(first().attributes["name"]).isEqualTo("expires")
+                            assertThat(first().attributes["type"]).isEqualTo("datetime-local")
+                            assertThat(first().attributes["required"]).isNull()
+                        }
+
+                        findAll("button") {
+                            assertThat(size).isEqualTo(1)
+                            assertThat(first().attributes["type"]).isEqualTo("submit")
+                        }
+                    }
+
+                    findAll("#laster") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(first().tagName).isEqualTo("div")
+                        assertThat(first().attributes["style"]).contains("display: none;")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Skal generere token og e-post mal`() {
+        val tokenRequest = TokenRequestDTO.genererTilfeldig()
+        val token = "Noe beskrivende tekst her: Bearer 1234567890abcdef"
+
+        every { tokenService.genererToken(tokenRequest) } returns token
+        every { tokenService.genererOneTimeSecret(any()) } returns URI.create("https://example.com/one-time-secret")
+        every { tokenService.oneTimeSecretPassphrase } returns "passphrase"
+
+        skrape(HttpFetcher) {
+            request {
+                url = "$lokalBaseUrl/token/generer"
+                method = Method.POST
+                body {
+                    form {
+                        "konsumentId" to tokenRequest.konsumentId.toString()
+                        "expires" to tokenRequest.expires.toString()
+                    }
+                }
+            }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.OK.code) }
+                assertThat(contentType).contains(ContentType.TEXT_HTML.mimeType)
+                htmlDocument {
+                    findAll("h2") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(text).isEqualTo("Token for konsument: ${tokenRequest.konsumentId}")
+                    }
+
+                    findAll("p") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(text).isEqualTo("Utløpsdato: ${tokenRequest.expires}")
+                    }
+
+                    findAll("label") {
+                        assertThat(size).isEqualTo(2)
+                        assertThat(map { it.text }).containsExactly(
+                            "Kopier token",
+                            "Kopier e-postmal"
+                        )
+                    }
+
+                    findAll("input") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(first().attributes["id"]).isEqualTo("token")
+                        assertThat(first().attributes["value"]).isEqualTo(token.split("Bearer ")[1])
+                        assertThat(first().attributes["disabled"]).isEqualTo(true.toString())
+                    }
+
+                    findAll("textarea") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(first().attributes["id"]).isEqualTo("epostmal")
+                        assertThat(first().text).contains("https://example.com/one-time-secret")
+                        assertThat(first().text).contains("passphrase")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Skal vise error-siden ved feil i generering av token`() {
+        val feilmelding = "Feil ved generering av token"
+
+        every { tokenService.genererToken(any()) } throws RuntimeException(feilmelding)
+
+        skrape(HttpFetcher) {
+            request {
+                url = "$lokalBaseUrl/token/generer"
+                method = Method.POST
+                body {
+                    form {
+                        "konsumentId" to UUID.randomUUID().toString()
+                        "expires" to LocalDateTime.now().toString()
+                    }
+                }
+            }
+            response {
+                status { assertThat(code).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.code) }
+                assertThat(contentType).contains(ContentType.TEXT_HTML.mimeType)
+                htmlDocument {
+                    findAll("h2") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(text).isEqualTo("Åisann, det skjedde visst noe feil!")
+                    }
+
+                    findAll("pre") {
+                        assertThat(size).isEqualTo(1)
+                        assertThat(text).contains(feilmelding)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Bruker [skrape{it}](https://docs.skrape.it/docs) for å parse html-en for sidene og verifiserer innholdet i elementene, slik at plassering og rekkefølge av elementene ikke skal ha noe å si der det ikke er relevant