### PR TITLE
Fjern CPU-limit

### DIFF
--- a/naiserator.yml
+++ b/naiserator.yml
@@ -22,7 +22,6 @@ spec:
         thresholdPercentage: 50
   resources:
     limits:
-      cpu: 1000m
       memory: 1536Mi
     requests:
       cpu: 20m


### PR DESCRIPTION
Fjerner `spec.resources.limits.cpu` fra nais-konfigen, i tråd med anbefalt praksis for nais-applikasjoner.

Se [Nais good practices](https://docs.nais.io/workloads/explanations/good-practices/index.html#set-reasonable-resource-requests-and-limits).